### PR TITLE
Mejorar Dockerfile en peso y puerto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM httpd:latest
+FROM httpd:2.4.59-alpine
 COPY . /usr/local/apache2/htdocs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM httpd:2.4.59-alpine
 COPY . /usr/local/apache2/htdocs/
+EXPOSE 80


### PR DESCRIPTION
Se actualiza la versión de la imagen **httd** por **2.4.59-alpine** debido a que el **latest** generaba un tamaño muy grande! 

Adicional, se forza a que el **puerto** expuesto sea el **80**, debido a que es posible que en **apilamiento** de imagenes (as build) se sobre escriban los puertos default.